### PR TITLE
Upgrade gradle version to use java21

### DIFF
--- a/Java/gradle/wrapper/gradle-wrapper.properties
+++ b/Java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/Kotlin/build.gradle
+++ b/Kotlin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.4.10"
+    id "org.jetbrains.kotlin.jvm" version "1.9.20"
 }
 
 repositories {

--- a/Kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/Kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
-#Wed Jun 24 17:17:39 BST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
- Java21을 사용하기 위해 Gradle version을 8.5로 upgrade 합니다. 
- Kotlin으로 함께 학습 할 예정이기 때문에 Gradle과 버전 호환성을 맞춥니다.
- 버전 호환성은 [Gradle 공식 문서](https://docs.gradle.org/current/userguide/compatibility.html)를 참고 합니다.